### PR TITLE
fix(auth): secure default authorization policies

### DIFF
--- a/FunnyActivities.WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/FunnyActivities.WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -221,15 +221,14 @@ public static class ServiceCollectionExtensions
                            context.User.IsInRole("User");
                 }));
 
-            // Add a default policy that allows anonymous access
+            // Require authenticated users by default for [Authorize] endpoints.
             options.DefaultPolicy = new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
-                .RequireAssertion(context => true) // Allow all requests to pass through
+                .RequireAuthenticatedUser()
                 .Build();
 
-            // Fallback policy for when no policy is specified
-            options.FallbackPolicy = new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
-                .RequireAssertion(context => true) // Allow all requests to pass through
-                .Build();
+            // Keep fallback open so only endpoints explicitly decorated with
+            // authorization metadata are protected.
+            options.FallbackPolicy = null;
         });
         return services;
     }


### PR DESCRIPTION
## Adım 1 - Authorization güvenliği

Bu PR canlıya geçiş planındaki ilk adımı uygular:
- `DefaultPolicy` artık `RequireAuthenticatedUser()` kullanıyor.
- `FallbackPolicy` `null` yapıldı; böylece sadece açıkça authorization metadata taşıyan endpoint'ler korunur.

## Neden
Önceki `RequireAssertion(context => true)` kullanımı, `[Authorize]` davranışını etkisizleştirip auth bypass riski oluşturuyordu.

## Doğrulama
- `dotnet build FunnyActivities.WebAPI/FunnyActivities.WebAPI.csproj -c Release` başarılı.