### PR TITLE
fix(cors): enforce production allowlist policy

### DIFF
--- a/FunnyActivities.WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/FunnyActivities.WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -257,8 +257,15 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    public static IServiceCollection AddCors(this IServiceCollection services)
+    public static IServiceCollection AddCors(this IServiceCollection services, IConfiguration configuration)
     {
+        var configuredOrigins = configuration.GetSection("Cors:AllowedOrigins").Get<string[]>();
+        if (configuredOrigins is { Length: > 0 })
+        {
+            services.AddCustomCors(configuredOrigins);
+            return services;
+        }
+
         services.AddCustomCors(new[] {
             "http://localhost:3000",
             "https://localhost:3000",

--- a/FunnyActivities.WebAPI/Program.cs
+++ b/FunnyActivities.WebAPI/Program.cs
@@ -68,7 +68,7 @@ FunnyActivities.WebAPI.Extensions.ServiceCollectionExtensions.AddApiVersioning(b
 builder.Services.AddSwagger();
 
 // CORS (Cross-Origin Resource Sharing) politikasini ekle
-FunnyActivities.WebAPI.Extensions.ServiceCollectionExtensions.AddCors(builder.Services);
+FunnyActivities.WebAPI.Extensions.ServiceCollectionExtensions.AddCors(builder.Services, builder.Configuration);
 
 // Veritabani DbContext'ini ekle
 builder.Services.AddDatabase(builder.Configuration);
@@ -173,7 +173,7 @@ app.UseHttpMetrics();
 
 // CORS middleware'ini ekle. Tarayicilarin farkli domain'lerden API'ye erisimine izin verir.
 // Guvenlik middleware'larindan (Authentication/Authorization) once gelmelidir.
-app.UseCors("AllowAllOrigins"); // Development icin tum origin'lere izin ver
+app.UseCors(app.Environment.IsDevelopment() ? "AllowAllOrigins" : "AllowSpecificOrigins");
 
 // Kimlik dogrulama (Authentication) middleware'ini ekle. Gelen JWT'yi dogrular.
 app.UseAuthentication();

--- a/FunnyActivities.WebAPI/appsettings.Development.json
+++ b/FunnyActivities.WebAPI/appsettings.Development.json
@@ -2,6 +2,16 @@
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=funnyactivities;Username=postgres;Password=devpassword"
   },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:3000",
+      "https://localhost:3000",
+      "http://localhost:3001",
+      "https://localhost:3001",
+      "http://localhost:8080",
+      "https://localhost:8080"
+    ]
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Debug",

--- a/FunnyActivities.WebAPI/appsettings.json
+++ b/FunnyActivities.WebAPI/appsettings.json
@@ -167,6 +167,14 @@
     "RefreshTokenExpiryDays": 7
   },
   "FrontendUrl": "http://localhost:3000",
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:3000",
+      "https://localhost:3000",
+      "http://localhost:3001",
+      "https://localhost:3001"
+    ]
+  },
   "IpRateLimiting": {
     "EnableEndpointRateLimiting": true,
     "StackBlockedRequests": false,


### PR DESCRIPTION
## Adım 2 - CORS production allowlist

Bu PR canlıya geçiş planındaki ikinci adımı uygular:
- CORS origin listesi artık `Cors:AllowedOrigins` config'inden okunuyor.
- Uygulama `Development` ortamında `AllowAllOrigins`, diğer ortamlarda `AllowSpecificOrigins` kullanıyor.
- `appsettings.json` ve `appsettings.Development.json` içine `Cors:AllowedOrigins` eklendi.

## Neden
Prod ortamda `AllowAllOrigins` açık kalması güvenlik riski oluşturur. Bu değişiklikle production trafiği yalnızca açıkça tanımlanan origin’lerden kabul edilir.

## Doğrulama
- `dotnet build FunnyActivities.WebAPI/FunnyActivities.WebAPI.csproj -c Release` başarılı.