### PR TITLE
fix(proxy): apply forwarded headers before https redirection

### DIFF
--- a/FunnyActivities.WebAPI/Program.cs
+++ b/FunnyActivities.WebAPI/Program.cs
@@ -165,9 +165,6 @@ if (app.Environment.IsDevelopment())
 // Hatalari merkezi olarak yakalamak icin custom exception middleware'ini kullan
 app.UseCustomExceptionHandling();
 
-// Gelen istekleri HTTP'den HTTPS'e yonlendir
-app.UseHttpsRedirection();
-
 var forwardedHeadersOptions = new ForwardedHeadersOptions
 {
     ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
@@ -175,6 +172,9 @@ var forwardedHeadersOptions = new ForwardedHeadersOptions
 forwardedHeadersOptions.KnownNetworks.Clear();
 forwardedHeadersOptions.KnownProxies.Clear();
 app.UseForwardedHeaders(forwardedHeadersOptions);
+
+// Gelen istekleri HTTP'den HTTPS'e yonlendir
+app.UseHttpsRedirection();
 
 // Yonlendirme (Routing) middleware'ini ekle. Bu, istegin hangi endpoint'e gidecegini belirler.
 app.UseRouting();


### PR DESCRIPTION
## Summary
- move `UseForwardedHeaders` before `UseHttpsRedirection`
- keep proxy trust configuration (`KnownNetworks` / `KnownProxies`) unchanged

## Why
When running behind reverse proxies (Caddy/Nginx), HTTPS redirect must see `X-Forwarded-Proto` first; otherwise redirect loops or wrong scheme detection can happen.

## Validation
- `dotnet build FunnyActivities.WebAPI/FunnyActivities.WebAPI.csproj -c Release --no-restore`
