### PR TITLE
fix(deploy): align production frontend url and cors env

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,5 +1,6 @@
 APP_DOMAIN=api.example.com
 FILES_DOMAIN=files.example.com
+FRONTEND_URL=https://app.example.com
 LETSENCRYPT_EMAIL=admin@example.com
 
 POSTGRES_DB=funnyactivities
@@ -14,11 +15,8 @@ JWT_REFRESH_DAYS=7
 
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=change-me-strong-minio-password
-MINIO_EXTERNAL_ENDPOINT=https://files.example.com
 
 SENDGRID_API_KEY=
 TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=
 TWILIO_FROM_NUMBER=
-
-GRAFANA_ADMIN_PASSWORD=change-me-grafana-admin-password

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -66,12 +66,16 @@ services:
       MinIO__AccessKey: ${MINIO_ROOT_USER:?MINIO_ROOT_USER_required}
       MinIO__SecretKey: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD_required}
       MinIO__UseSSL: false
+      MinIO__CorsOrigins__0: ${FRONTEND_URL:?FRONTEND_URL_required}
+      MinIO__CorsOrigins__1: https://${APP_DOMAIN:?APP_DOMAIN_required}
       JwtSettings__SecretKey: ${JWT_SECRET_KEY:?JWT_SECRET_KEY_required}
       JwtSettings__Issuer: ${JWT_ISSUER:-FunnyActivities}
       JwtSettings__Audience: ${JWT_AUDIENCE:-FunnyActivitiesUsers}
       JwtSettings__ExpiryMinutes: ${JWT_EXPIRY_MINUTES:-60}
       JwtSettings__RefreshTokenExpiryDays: ${JWT_REFRESH_DAYS:-7}
-      FrontendUrl: https://${APP_DOMAIN:?APP_DOMAIN_required}
+      FrontendUrl: ${FRONTEND_URL:?FRONTEND_URL_required}
+      Cors__AllowedOrigins__0: ${FRONTEND_URL:?FRONTEND_URL_required}
+      Cors__AllowedOrigins__1: https://${APP_DOMAIN:?APP_DOMAIN_required}
       SendGrid__ApiKey: ${SENDGRID_API_KEY:-}
       Twilio__AccountSid: ${TWILIO_ACCOUNT_SID:-}
       Twilio__AuthToken: ${TWILIO_AUTH_TOKEN:-}

--- a/docs/production-deploy-contabo.md
+++ b/docs/production-deploy-contabo.md
@@ -26,6 +26,12 @@ Asagidaki iki A kaydini VPS public IP'sine yonlendirin:
 - `APP_DOMAIN` (ornek: `api.example.com`)
 - `FILES_DOMAIN` (ornek: `files.example.com`)
 
+Ek olarak `.env.production` icinde:
+
+- `FRONTEND_URL` (ornek: `https://app.example.com`, sonuna `/` koymayin)
+
+Not: Frontend farkli bir platformda host ediliyorsa `FRONTEND_URL` o canli frontend adresi olmalidir.
+
 ## 4) Production stack'i kaldirma
 
 Asagidaki komutla sistemi ayaga kaldirin:
@@ -57,7 +63,7 @@ docker compose -f docker-compose.prod.yml --env-file .env.production up -d --bui
 ## Notlar
 
 - Bu stack production icin gereksiz monitoring container'larini (prometheus/grafana/jaeger/alertmanager) dahil etmez.
-- Canliya cikmadan once güvenlik PR'larinin merge edilmesi gerekir:
+- Canliya cikmadan once guvenlik PR'larinin merge edilmesi gerekir:
   - auth policy
   - CORS allowlist
   - secret management


### PR DESCRIPTION
## Summary
- add required `FRONTEND_URL` production env variable
- wire `FrontendUrl`, `Cors:AllowedOrigins`, and `MinIO:CorsOrigins` from production env
- remove unused env keys from `.env.production.example` and update deploy doc

## Why
Production compose used API domain for `FrontendUrl` and did not override CORS origins, which can break frontend auth flows and browser calls after go-live.

## Validation
- `docker compose -f docker-compose.prod.yml --env-file .env.production.example config`
- `dotnet build FunnyActivities.WebAPI/FunnyActivities.WebAPI.csproj -c Release --no-restore`
