### PR TITLE
ci: fix test matrix & slack notify guard

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,10 +48,14 @@ jobs:
         dotnet-version: ${{ env.DOTNET_VERSION }}
     - name: Restore dependencies
       run: dotnet restore FunnyActivities.sln
-    - name: Run unit tests
-      run: dotnet test FunnyActivities.Domain.UnitTests/FunnyActivities.Domain.UnitTests.csproj FunnyActivities.Application.UnitTests/FunnyActivities.Application.UnitTests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore --verbosity normal --collect:"XPlat Code Coverage" --settings coverlet.runsettings --results-directory ./TestResults
-    - name: Run integration tests
-      run: dotnet test FunnyActivities.IntegrationTests/FunnyActivities.IntegrationTests.csproj FunnyActivities.Api.IntegrationTests/FunnyActivities.Api.IntegrationTests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore --verbosity normal --collect:"XPlat Code Coverage" --settings coverlet.runsettings --results-directory ./TestResults
+    - name: Run domain unit tests
+      run: dotnet test tests/unit/dotnet/FunnyActivities.Domain.UnitTests/FunnyActivities.Domain.UnitTests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore --verbosity normal --collect:"XPlat Code Coverage" --settings coverlet.runsettings --results-directory ./TestResults
+    - name: Run application unit tests
+      run: dotnet test tests/unit/dotnet/FunnyActivities.Application.UnitTests/FunnyActivities.Application.UnitTests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore --verbosity normal --collect:"XPlat Code Coverage" --settings coverlet.runsettings --results-directory ./TestResults
+    - name: Run infrastructure integration tests
+      run: dotnet test tests/integration/dotnet/FunnyActivities.IntegrationTests/FunnyActivities.IntegrationTests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore --verbosity normal --collect:"XPlat Code Coverage" --settings coverlet.runsettings --results-directory ./TestResults
+    - name: Run API integration tests
+      run: dotnet test tests/integration/dotnet/FunnyActivities.Api.IntegrationTests/FunnyActivities.Api.IntegrationTests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore --verbosity normal --collect:"XPlat Code Coverage" --settings coverlet.runsettings --results-directory ./TestResults
     - name: Upload coverage reports
       uses: actions/upload-artifact@v4
       with:
@@ -147,12 +151,12 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     needs: [deploy-dev, deploy-staging, deploy-prod]
-    if: failure()
+    if: ${{ failure() && secrets.SLACK_BOT_TOKEN != '' && secrets.SLACK_CHANNEL_ID != '' }}
     steps:
     - name: Send Slack notification
       uses: slackapi/slack-github-action@v1.26.0
       with:
-        channel-id: 'your-channel-id'
+        channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
         slack-message: "CI/CD Pipeline failed: ${{ github.workflow }} - ${{ github.run_id }} - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- split dotnet test into separate domain/app + infra/api runs to avoid MSB1008
- use correct test project paths (tests/unit/dotnet and tests/integration/dotnet)
- guard slack notify job behind secrets and reuse channel id from secrets

## Validation
- local: dotnet test tests/unit/dotnet/FunnyActivities.Application.UnitTests/FunnyActivities.Application.UnitTests.csproj --configuration Release --no-restore (pass)
- note: pipeline should now pass test step; notify remains no-op unless secrets set.