### PR TITLE
ci: add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 env:
   DOTNET_VERSION: '8.0.x'


### PR DESCRIPTION
Enable manual runs of the main pipeline. Adds workflow_dispatch trigger to .github/workflows/main.yml for ad‑hoc reruns without needing a new commit.