### PR TITLE
Make HTTPS optional for VPS deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,15 @@ TestResults/
 # Secrets
 secrets.json
 appsettings.*.json
+
+# Deployment artifacts (local)
+publish/
+publish.zip
+frontend-build.zip
+deploy_vps_key*
+plink.exe
+pscp.exe
+askpass.bat
+funnyactivities.service
+nginx_funny.conf
+client/.env.production

--- a/FunnyActivities.WebAPI/Program.cs
+++ b/FunnyActivities.WebAPI/Program.cs
@@ -174,7 +174,8 @@ forwardedHeadersOptions.KnownProxies.Clear();
 app.UseForwardedHeaders(forwardedHeadersOptions);
 
 // Gelen istekleri HTTP'den HTTPS'e yonlendir
-app.UseHttpsRedirection();
+// HTTPS sertifikasi hazir olmadigi icin su an kapali; Nginx uzerinden TLS eklenince acilacak
+// app.UseHttpsRedirection();
 
 // Yonlendirme (Routing) middleware'ini ekle. Bu, istegin hangi endpoint'e gidecegini belirler.
 app.UseRouting();

--- a/client/.env.production.example
+++ b/client/.env.production.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=/api


### PR DESCRIPTION
- Keep HTTPS redirection disabled for VPS/Nginx TLS setup\n- Add production API URL example for frontend\n- Ignore local deploy artifacts (publish zips, keys, binaries)