### PR TITLE
Add VPS deployment job and gate Azure deploys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, test]
     environment: dev
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AZURE_PUBLISH_PROFILE_DEV != '' }}
     steps:
     - name: Download build artifacts
       uses: actions/download-artifact@v4
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, test]
     environment: staging
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AZURE_PUBLISH_PROFILE_STAGING != '' }}
     steps:
     - name: Download build artifacts
       uses: actions/download-artifact@v4
@@ -141,7 +141,7 @@ jobs:
     environment:
       name: prod
       url: https://funnyactivities-prod.azurewebsites.net
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AZURE_PUBLISH_PROFILE_PROD != '' }}
     steps:
     - name: Download build artifacts
       uses: actions/download-artifact@v4
@@ -155,6 +155,58 @@ jobs:
         slot-name: production
         publish-profile: ${{ secrets.AZURE_PUBLISH_PROFILE_PROD }}
         package: ./publish
+
+  deploy-vps:
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.VPS_HOST != '' && secrets.VPS_USER != '' }}
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: publish-artifact
+        path: ./publish
+
+    - name: Create package
+      run: tar czf publish.tar.gz -C publish .
+
+    - name: Prepare SSH credentials
+      id: sshcred
+      shell: bash
+      run: |
+        if [ -n "${{ secrets.VPS_SSH_KEY }}" ]; then
+          echo "${{ secrets.VPS_SSH_KEY }}" > key.pem
+          chmod 600 key.pem
+          echo "method=key" >> $GITHUB_OUTPUT
+        elif [ -n "${{ secrets.VPS_PASSWORD }}" ]; then
+          echo "method=password" >> $GITHUB_OUTPUT
+        else
+          echo "No VPS_SSH_KEY or VPS_PASSWORD provided." >&2
+          exit 1
+        fi
+
+    - name: Upload package (key auth)
+      if: steps.sshcred.outputs.method == 'key'
+      run: |
+        scp -o StrictHostKeyChecking=accept-new -i key.pem publish.tar.gz ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/tmp/publish.tar.gz
+    - name: Upload package (password auth)
+      if: steps.sshcred.outputs.method == 'password'
+      run: |
+        sudo apt-get update && sudo apt-get install -y sshpass
+        sshpass -p "${{ secrets.VPS_PASSWORD }}" scp -o StrictHostKeyChecking=accept-new publish.tar.gz ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/tmp/publish.tar.gz
+
+    - name: Deploy on VPS (key auth)
+      if: steps.sshcred.outputs.method == 'key'
+      run: |
+        ssh -o StrictHostKeyChecking=accept-new -i key.pem ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} \
+          "rm -rf /var/www/funnyactivities/publish && mkdir -p /var/www/funnyactivities/publish && tar xzf /tmp/publish.tar.gz -C /var/www/funnyactivities/publish && systemctl restart funnyactivities"
+
+    - name: Deploy on VPS (password auth)
+      if: steps.sshcred.outputs.method == 'password'
+      run: |
+        sudo apt-get update && sudo apt-get install -y sshpass
+        sshpass -p "${{ secrets.VPS_PASSWORD }}" ssh -o StrictHostKeyChecking=accept-new ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} \
+          "rm -rf /var/www/funnyactivities/publish && mkdir -p /var/www/funnyactivities/publish && tar xzf /tmp/publish.tar.gz -C /var/www/funnyactivities/publish && systemctl restart funnyactivities"
 
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add optional deploy-vps job that uploads publish artifact to VPS and restarts systemd service\n- Support SSH key or password via secrets (VPS_HOST, VPS_USER, VPS_SSH_KEY or VPS_PASSWORD)\n- Guard Azure deploy jobs so they run only if corresponding publish profile secret is set